### PR TITLE
Fix missing files and config for eos_token and preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ conda activate aguvis
 
 3. Install PyTorch and dependencies:
 ```bash
-conda install pytorch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 pytorch-cuda=12.1 -c pytorch -c nvidia
+conda install pytorch torchvision torchaudio pytorch-cuda -c pytorch -c nvidia
 pip install -e .
 ```
 

--- a/src/aguvis/trainer.py
+++ b/src/aguvis/trainer.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from typing import Optional
+from functools import wraps
 
 import torch
 import torch.distributed as dist
@@ -30,7 +31,7 @@ def rank0_print(*args):
             print(f"Rank {dist.get_rank()}: ", *args)
     else:
         print(*args)
-
+   
 
 def maybe_zero_3(param, ignore_status=False, name=None):
     from deepspeed import zero
@@ -69,6 +70,48 @@ def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: st
 
 
 class AGUVISTrainer(Trainer):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        original_save = self._save
+        original_save_model = self.save_model
+        
+        def modify_eos_token(func):
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                tokenizer = self.processing_class.tokenizer
+                old_config_id = self.model.config.eos_token_id
+                old_eos_token = tokenizer.eos_token
+                old_generation_config_eos_token_id = self.model.generation_config.eos_token_id if hasattr(self.model, 'generation_config') else None
+                
+                try:
+                    new_eos_token_id = tokenizer.convert_tokens_to_ids("<|diff_marker|>")
+                    self.model.config.eos_token_id = [new_eos_token_id]
+                    tokenizer.eos_token = "<|diff_marker|>"
+                    if hasattr(self.model, 'generation_config'):
+                        self.model.generation_config.eos_token_id = [new_eos_token_id]
+                    
+                    print("Set eos token id to", new_eos_token_id)
+                    print("Set eos token to", "<|diff_marker|>")
+                    print("Set generation config eos token id to", [new_eos_token_id])
+                    
+                    result = func(*args, **kwargs)
+                    return result
+                finally:
+                    self.model.config.eos_token_id = old_config_id
+                    tokenizer.eos_token = old_eos_token
+                    if hasattr(self.model, 'generation_config') and old_generation_config_eos_token_id is not None:
+                        self.model.generation_config.eos_token_id = old_generation_config_eos_token_id
+                    
+                    print("Set eos token id back to", old_config_id)
+                    print("Set eos token back to", old_eos_token)
+                    if old_generation_config_eos_token_id is not None:
+                        print("Set generation config eos token id back to", old_generation_config_eos_token_id)
+            return wrapper
+
+        self._save = modify_eos_token(original_save)
+        self.save_model = modify_eos_token(original_save_model)
 
     def create_accelerator_and_postprocess(self):
         grad_acc_kwargs = {"num_steps": self.args.gradient_accumulation_steps}

--- a/train.py
+++ b/train.py
@@ -192,7 +192,7 @@ def train(attn_implementation="flash_attention_2"):
 
     trainer = AGUVISTrainer(
         model=model,
-        tokenizer=tokenizer,
+        processing_class=data_args.processor,
         args=training_args,
         **data_module,
     )


### PR DESCRIPTION
This pull request includes several changes to the `AGUVISTrainer` class in `src/aguvis/trainer.py` to enhance the handling of the end-of-sequence (EOS) token during model saving. Additionally, a minor change was made in `train.py` to update the initialization of the `AGUVISTrainer`.

Enhancements to `AGUVISTrainer`:

* Added a decorator `modify_eos_token` to temporarily change the EOS token and its ID during the saving process, ensuring the model's configuration is reverted back after saving.
* Updated the `__init__` method to wrap the `_save` and `save_model` methods with the `modify_eos_token` decorator.

Minor updates:

* Imported the `wraps` function from `functools` to create the `modify_eos_token` decorator.
* Modified the initialization of `AGUVISTrainer` in `train.py` to use `processing_class` instead of `tokenizer`.
* Fix the `torch` version, 2.1.x is too low... should be > 2.3